### PR TITLE
Use GCC attribute for shared object constructor/destructor routines

### DIFF
--- a/ladspa_dsp.c
+++ b/ladspa_dsp.c
@@ -243,7 +243,7 @@ static void cleanup_dsp(LADSPA_Handle inst)
 	free(d);
 }
 
-void _init()
+void __attribute__((constructor)) ladspa_dsp_init()
 {
 	int i, k;
 	char **pn, *env, *tmp;
@@ -311,7 +311,7 @@ void _init()
 	}
 }
 
-void _fini() {
+void __attribute__((destructor)) ladspa_dsp_fini() {
 	int i, k;
 	for (k = 0; k < n_configs; ++k) {
 		free((char *) descriptors[k].Label); /* note: dsp_descriptor->Name is the same data */


### PR DESCRIPTION
Found an interesting linker bug when porting over the build system... looked into it and found that `ladspa_dsp` was using the deprecated init/cleanup routine prototypes.

> Libraries should export initialization and cleanup routines using the gcc ```__attribute__((constructor))``` and ```__attribute__((destructor))``` function attributes. See the gcc info pages for information on these. Constructor routines are executed before ```dlopen``` returns (or before ```main()``` is started if the library is loaded at load time). Destructor routines are executed before ```dlclose``` returns (or after ```exit()``` or completion of ```main()``` if the library is loaded at load time). The C prototypes for these functions are:
```C
void __attribute__ ((constructor)) my_init(void);
void __attribute__ ((destructor)) my_fini(void);
```

> Historically there have been two special functions, _init and _fini that can be used to control constructors and destructors. However, they are obsolete, and their use can lead to unpredicatable results. Your libraries should not use these; use the function attributes constructor and destructor above instead.

More info: http://www.faqs.org/docs/Linux-HOWTO/Program-Library-HOWTO.html#INIT-AND-CLEANUP
