### PR TITLE
Add support for Channel command in Room EQ Wizard conversion script

### DIFF
--- a/scripts/rew_to_dsp.sh
+++ b/scripts/rew_to_dsp.sh
@@ -12,6 +12,9 @@ AWK_SCRIPT='
 	if ($1=="Preamp:" && $2!=0) {
 		print "gain", $2
 	}
+	else if ($1=="Channel:") {
+		print ":" $2
+	}
 	else if ($1=="Filter" && $3=="ON") {
 		if ($4=="PK" && $9!=0) {
 			gsub(",", "", $6)


### PR DESCRIPTION
Simple modification to support the `Channel: x` specification when converting from EqualizerAPO / Room EQ Wizard scripts.