### PR TITLE
Fix ladspa_dsp config path for users w/o $HOME

### DIFF
--- a/ladspa_dsp.c
+++ b/ladspa_dsp.c
@@ -177,6 +177,8 @@ static void load_configs(void)
 			i = strlen(env) + strlen(DEFAULT_XDG_CONFIG_DIR) + strlen(DEFAULT_CONFIG_DIR) + 1 + strlen(GLOBAL_CONFIG_DIR) + 1;
 			path = calloc(i, sizeof(char));
 			snprintf(path, i, "%s%s%s:%s", env, DEFAULT_XDG_CONFIG_DIR, DEFAULT_CONFIG_DIR, GLOBAL_CONFIG_DIR);
+		} else {
+			path = strdup(GLOBAL_CONFIG_DIR);
 		}
 	}
 	LOG_FMT(LL_VERBOSE, "info: config path: %s", path);


### PR DESCRIPTION
This fixes a bug where /etc/ladspa_dsp/config would not be loaded, e.g. systemd services with DynamicUser=true, most notably, such services include raspotify and snapclient so I hope this will save at least 1 hacker a few headaches :^)

`journalctl -u raspotify.service` output example prior to this fix:
```
Oct 05 20:02:58 raspberrypi2 librespot[4436]: ladspa_dsp: error: no config files found
Oct 05 20:02:58 raspberrypi2 librespot[4436]: ALSA lib pcm_ladspa.c:1509:(snd_pcm_ladspa_add_plugin) Unable to find or load plugin 'ladspa_dsp' ID 0, path '/usr/lib/ladspa'
Oct 05 20:02:58 raspberrypi2 librespot[4436]: [2022-10-05T18:02:58Z ERROR librespot_playback::player] Audio Sink Error Connection Refused: <AlsaSink> Device default May be Invalid, Busy, or Already in Use, ALS>
Oct 05 20:02:58 raspberrypi2 systemd[1]: raspotify.service: Main process exited, code=exited, status=1/FAILURE
```
